### PR TITLE
Enhance configurator design with dark mode and richer summary

### DIFF
--- a/render.js
+++ b/render.js
@@ -48,6 +48,7 @@ export function render(){
   const hingeLeft = /links/.test(state.openDirection);
   const frameRx = state.frameForm==='Elegant'?18:state.frameForm==='Modern'?0:8;
   const doorColor = state.view==='Außen' ? state.outHex : (state.inSame? state.outHex : state.inHex);
+  document.body.classList.toggle('dark', night);
 
   const wallGrad = night?`url(#wallNight)`:`url(#wallDay)`;
   const lampFill = night? '#ffdf7a':'#ffd54f';
@@ -126,6 +127,8 @@ export function render(){
   // Summary UI
   $('#sumView').textContent = state.view;
   const sum = $('#summaryGrid'); sum.innerHTML = '';
+  const outColorName = $('#colOut').selectedOptions[0].textContent;
+  const inColorName = state.inSame ? 'gleich Außen' : $('#colIn').selectedOptions[0].textContent;
   const rows = [
     ['Hersteller', state.manufacturer],
     ['Serie', state.series],
@@ -133,6 +136,10 @@ export function render(){
     ['Öffnungsrichtung', state.openDirection],
     ['Türform', state.doorForm],
     ['Modell', state.model],
+    ['Außenfarbe', outColorName],
+    ['Innenfarbe', inColorName],
+    ['Breite', state.width + ' mm'],
+    ['Höhe', state.height + ' mm'],
   ];
   rows.forEach(([l,v])=>{
     const d=document.createElement('div'); d.innerHTML=`<div class="muted" style="font-size:12px">${l}</div><div style="font-weight:600">${v}</div>`;

--- a/style.css
+++ b/style.css
@@ -2,6 +2,10 @@
     --bg:#f3f4f6;--card:#fff;--text:#0f172a;--muted:#6b7280;--border:#e5e7eb;
     --brand:#111;--brand-2:#1f2937;
   }
+  body.dark{
+    --bg:#0f172a;--card:#1e293b;--text:#f1f5f9;--muted:#94a3b8;--border:#334155;
+    --brand:#111;--brand-2:#1f2937;
+  }
   *{box-sizing:border-box}
   body{margin:0;font:14px/1.45 system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial;color:var(--text);background:var(--bg)}
   .wrap{max-width:1320px;margin:auto;padding:16px;display:grid;grid-template-columns:1fr;gap:16px}
@@ -11,10 +15,10 @@
   .sticky{position:sticky;top:12px;max-height:calc(100vh - 24px);display:flex;flex-direction:column}
   .row{display:flex;align-items:center;justify-content:space-between;gap:12px}
   .muted{color:var(--muted)}
-  .btn{border:1px solid var(--border);background:#fff;border-radius:999px;padding:.5rem .9rem;cursor:pointer}
-  .btn:is(:hover,:focus){background:#f3f4f6}
+  .btn{border:1px solid var(--border);background:var(--card);border-radius:999px;padding:.5rem .9rem;cursor:pointer}
+  .btn:is(:hover,:focus){background:var(--bg)}
   .seg{display:inline-flex;border:1px solid var(--border);border-radius:999px;overflow:hidden}
-  .seg button{padding:.45rem .9rem;border:0;background:#fff}
+  .seg button{padding:.45rem .9rem;border:0;background:var(--card)}
   .seg button.active{background:var(--brand);color:#fff}
   .divider{display:flex;align-items:center;gap:12px;margin:16px 0}
   .divider::before,.divider::after{content:"";height:1px;background:var(--border);flex:1}
@@ -22,14 +26,14 @@
   .grid-3{display:grid;grid-template-columns:repeat(3,1fr);gap:10px}
   .grid-4{display:grid;grid-template-columns:repeat(4,1fr);gap:10px}
   .grid-5{display:grid;grid-template-columns:repeat(5,1fr);gap:10px}
-  .opt{border:1px solid var(--border);border-radius:14px;padding:8px;text-align:center;cursor:pointer;background:#fff}
-  .opt.active{outline:2px solid #111;border-color:#111}
+  .opt{border:1px solid var(--border);border-radius:14px;padding:8px;text-align:center;cursor:pointer;background:var(--card)}
+  .opt.active{outline:2px solid var(--brand);border-color:var(--brand)}
   .swatch{position:relative;height:46px;border-radius:10px;border:1px solid var(--border);overflow:hidden}
   .swatch span{position:absolute;left:6px;bottom:4px;font-size:10px;background:#fff;padding:1px 4px;border-radius:6px}
   label small{color:var(--muted)}
   .field{display:grid;gap:6px}
-  input,select{width:100%;border:1px solid var(--border);border-radius:10px;background:#fff;padding:.6rem .7rem}
+  input,select{width:100%;border:1px solid var(--border);border-radius:10px;background:var(--card);padding:.6rem .7rem}
   /* Live Scene box */
-  .scene{flex:1;border:1px solid var(--border);border-radius:14px;background:#f8fafc;display:grid;place-items:center;overflow:hidden;min-height:420px}
+  .scene{flex:1;border:1px solid var(--border);border-radius:14px;background:var(--card);display:grid;place-items:center;overflow:hidden;min-height:420px}
   .summary{margin-top:12px;border:1px solid var(--border);border-radius:14px;padding:12px}
   .sumgrid{display:grid;grid-template-columns:1fr 1fr;gap:8px}


### PR DESCRIPTION
## Summary
- support dark theme by toggling CSS variables and body class
- show selected colors and dimensions in the summary panel
- refactor styling to rely on theme variables for consistent look

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --input-type=module -e "import('./state.js'); import('./render.js');"`


------
https://chatgpt.com/codex/tasks/task_e_68c045a31ca4832b8dbfad32bfd90af7